### PR TITLE
update JDK install instructions, fixes #366

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ You can install `r5r`:
 
 ```
 
-Please bear in mind that you need to have *Java SE Development Kit 21* installed 
-on your computer to use `r5r`. No worries, you don't have to pay for it. The jdk 
-21 is freely available from the options below:
-- [OpenJDK](https://jdk.java.net/java-se-ri/21)
-- [Oracle](https://docs.oracle.com/en/java/javase/21/install/index.html)
+Please bear in mind that you need to have *Java Development Kit (JDK) 21* installed 
+on your computer to use `r5r`. No worries, you don't have to pay for it. There are
+numerous open-source JDK implementations, any of which should work with `r5r`. If you don't
+already have a preferred JDK, we recommend [Adoptium/Eclipse Temurin](https://adoptium.net/).
+Other open-source JDK implementations include [Amazon Corretto](https://aws.amazon.com/corretto/),
+and [Oracle OpenJDK](https://jdk.java.net/21/). You only need to install one JDK.
 
-If you don't know what version of Java you have installed on your computer, you 
+If you don't know what version of Java you have installed on your computer,
 can check it by running this on R console.
 
 ```R


### PR DESCRIPTION
Fix #366, make instructions for installing the JDK more clear and straightforward.