### PR TITLE
minor documentation fixes

### DIFF
--- a/r-package/R/r5r_cache.R
+++ b/r-package/R/r5r_cache.R
@@ -66,8 +66,7 @@ r5r_cache <- function(list_files = TRUE,
 
   # print file names
   if(isTRUE(list_files)){
-    message('Files currently chached:')
+    message('Files currently cached:')
     message(paste0(files, collapse = '\n'))
   }
 }
-

--- a/r-package/vignettes/detailed_itineraries.Rmd
+++ b/r-package/vignettes/detailed_itineraries.Rmd
@@ -136,7 +136,7 @@ knitr::include_graphics("https://github.com/ipeaGIT/r5r/blob/master/r-package/in
 
 ### 4.2 Keep geometry data in the output
 
-- Be default, `detailed_itineraries()` will not return the spatial geometry of results. To retrieve this information you can simply set `geometry = TRUE`.
+- Be default, `detailed_itineraries()` will return the spatial geometry of results. To prevent retrieving this information you can simply set `drop_geometry = TRUE`.
 
 
 


### PR DESCRIPTION
- Fixes type of message in r-package/R/r5r_cache.R
- Fixes wording in https://ipeagit.github.io/r5r/articles/detailed_itineraries.html?q=geometry#keep-geometry-data-in-the-output in accordance with the current implementation of `detailed_itineraries`