### PR TITLE
added arrive-by search to travel_time_matrix

### DIFF
--- a/r-package/R/assign.R
+++ b/r-package/R/assign.R
@@ -142,13 +142,29 @@ assign_mode <- function(mode, mode_egress, style) {
 #' @family assigning functions
 #'
 #' @keywords internal
-assign_departure <- function(datetime) {
-  checkmate::assert_posixct(
-    datetime,
-    len = 1,
-    any.missing = FALSE,
-    .var.name = "departure_datetime"
-  )
+assign_departure <- function(departure_datetime, arrival_datetime = NULL, max_trip_duration = NULL) {
+  if (!is.null(departure_datetime) && !is.null(arrival_datetime)) {
+    stop("Only one of 'departure_datetime' or 'arrival_datetime' can be provided, not both.")
+  }
+
+  if (!is.null(departure_datetime)) {
+    checkmate::assert_posixct(
+      departure_datetime,
+      len = 1,
+      any.missing = FALSE,
+      .var.name = "departure_datetime"
+    )
+    datetime <- departure_datetime
+  } else {
+    checkmate::assert_posixct(
+      arrival_datetime,
+      len = 1,
+      any.missing = FALSE,
+      .var.name = "arrival_datetime"
+    )
+    datetime <- arrival_datetime - as.difftime(max_trip_duration, units = "mins")
+  }
+
 
   tz <- attr(datetime, "tzone")
   if (is.null(tz)) tz <- ""
@@ -159,6 +175,29 @@ assign_departure <- function(datetime) {
   )
 
   return(datetime_list)
+}
+
+
+#' Check and assign time window
+#'
+#' This function checks whether an `arrival_datetime` is provided. If it is `NULL`,
+#' it returns the input `time_window`. Otherwise, it returns `max_trip_duration`.
+#'
+#' @param time_window A numeric or time-based value representing the default time window.
+#' @param max_trip_duration A numeric or time-based value representing the maximum duration allowed for a trip.
+#' @param arrival_datetime A datetime object or `NULL`. If not `NULL`, the function will return `max_trip_duration`.
+#'
+#' @return A value equal to either `time_window` or `max_trip_duration`, depending on whether `arrival_datetime` is `NULL`.
+#'
+#' @family assigning functions
+#'
+#' @keywords internal
+assign_time_window <- function(time_window, max_trip_duration, arrival_datetime) {
+  if (is.null(arrival_datetime)) {
+    return(time_window)
+  }
+
+  return(max_trip_duration)
 }
 
 


### PR DESCRIPTION
Here is an R wrapper to implement a fake arrive-by search using expanded_travel_time_matrix. The arrive by mode works automatically when the user passes through arrival_datetime and departure_datetime is NULL. Previously `travel_time_matrix` departure_datetime had a default of `Sys.time()`, I changed it to NULL as that seems more intuitive if the user is using arrive_by mode. I don't see it as a big issue as in 99% of cases the user is passing their own departure_datetime, it is very rare that the current time makes sense for published GTFS data.

Example code
```
data_path <- system.file("extdata/poa", package = "r5r")
r5r_core <- setup_r5(data_path)

points <- read.csv(file.path(data_path, "poa_points_of_interest.csv"))

arrival_datetime <- as.POSIXct(
  "13-05-2019 14:00:00",
  format = "%d-%m-%Y %H:%M:%S"
)

ttm <- travel_time_matrix(
  r5r_core,
  origins = points,
  destinations = points,
  mode = c("WALK", "TRANSIT"),
  arrival_datetime = arrival_datetime,
  departure_datetime = NULL,
  max_trip_duration = 20
)
```

You can compare this with the output of expanded travel time matrix to convince yourself that these are indeed the latest departures that will arrive before 14:00:00
```
departure_datetime <- as.POSIXct(
  "13-05-2019 13:40:00",
  format = "%d-%m-%Y %H:%M:%S"
)

ttm_expanded <- expanded_travel_time_matrix(
  r5r_core,
  origins = points,
  destinations = points,
  mode = c("WALK", "TRANSIT"),
  departure_datetime = departure_datetime,
  max_trip_duration = 20,
  time_window = 20,
)
```

You can also compare it to a "depart at" travel time matrix, however note that the depart at travel time matrix will have more routes, as the trip duration is fairly short at 20 minutes. So for example if a trip takes 18 minutes, the arrive by search can only look at the possibilities departing at 13:40, and 13:41. Wheares the depart at search by default looks at all departures between 13:40-13:50, so there will naturally be more routes that are possible in under 20 minutes.

```
ttm_depart_at <- travel_time_matrix(
  r5r_core,
  origins = points,
  destinations = points,
  mode = c("WALK", "TRANSIT"),
  departure_datetime = departure_datetime,
  max_trip_duration = 20
)
```

There are some things to consider about this implementation:

1. The filtering can be done in Java to make the code more efficient, as the complete travel time matrix is converted, processed and passed through from Java to R, which for longer trips will scale quickly as the time_window is equal to the max trip duration in this implementation. By doing the filtering in Java this issue could be avoided.
2.  This could feature could be moved to `expanded_travel_time_matrix` or even its own function `arrive_travel_time_matrix`. My reasoning behind this is that currently `travel_time_matrix` is a very efficient calculation. Arrive_by search is simply using `expanded_travel_time_matrix` so it has the same inefficiencies and thus would make sense to make the parameter as part of that function to aknowledge to the user that the function is much more costly. At the same time however, the result is more similar the a simple travel time matrix as only one travel time is given per route as opposed to multiple in the `expanded_travel_time_matrix`. So I think the most sense would be make a new function `arrive_travel_time_matrix` so that the user acknowledges that the function is much less efficient but only returns one trip per route. ALternatively we could issue a warning if the user is using arrive by mode to let them know this will be much slower for large calcualtions.

