### PR TITLE
added num of threads check to expanded ttm

### DIFF
--- a/r-package/R/expanded_travel_time_matrix.R
+++ b/r-package/R/expanded_travel_time_matrix.R
@@ -113,6 +113,8 @@ expanded_travel_time_matrix <- function(r5r_core,
   old_options <- options(datatable.optimize = Inf)
   on.exit(options(old_options), add = TRUE)
 
+  checkmate::assert_number(n_threads, lower = 1)
+
   old_dt_threads <- data.table::getDTthreads()
   dt_threads <- ifelse(is.infinite(n_threads), 0, n_threads)
   data.table::setDTthreads(dt_threads)


### PR DESCRIPTION
Standard TTM has this check, however expanded TTM was missing it. See:
https://github.com/ipeaGIT/r5r/blob/6985769524c6160b8501b6edd3081649e8ad3016/r-package/R/travel_time_matrix.R#L136

Brought expanded TTM inline with standard TTM.
