### PR TITLE
Fixes to fare documentation

### DIFF
--- a/r-package/R/fare_structure.R
+++ b/r-package/R/fare_structure.R
@@ -4,9 +4,7 @@
 #' calculated in [travel_time_matrix()], [expanded_travel_time_matrix()],
 #' [accessibility()] and [pareto_frontier()]. This fare structure can be
 #' manually edited and adjusted to the existing rules in your study area, as
-#' long as they stick to some basic premises. Please see fare structure
-#' vignette for more information on how the fare structure works:
-#' `vignette("fare_structure", package = "r5r")`.
+#' long as they stick to some basic premises. Please see the \link[vignette:fare_structure]{fare structure vignette} for more information.
 #'
 #' @template r5r_core
 #' @param base_fare A numeric. A base value used to populate the fare
@@ -341,7 +339,7 @@ assert_fare_structure <- function(fare_structure) {
     return(invisible(TRUE))
   } else {
     # This is an R5R fare structure object
-    
+
     element_names <- c(
       "max_discounted_transfers",
       "transfer_time_allowance",

--- a/r-package/R/fare_structure.R
+++ b/r-package/R/fare_structure.R
@@ -339,7 +339,6 @@ assert_fare_structure <- function(fare_structure) {
     return(invisible(TRUE))
   } else {
     # This is an R5R fare structure object
-
     element_names <- c(
       "max_discounted_transfers",
       "transfer_time_allowance",

--- a/r-package/man/setup_fare_structure.Rd
+++ b/r-package/man/setup_fare_structure.Rd
@@ -64,9 +64,7 @@ Creates a basic fare structure that describes how transit fares should be
 calculated in \code{\link[=travel_time_matrix]{travel_time_matrix()}}, \code{\link[=expanded_travel_time_matrix]{expanded_travel_time_matrix()}},
 \code{\link[=accessibility]{accessibility()}} and \code{\link[=pareto_frontier]{pareto_frontier()}}. This fare structure can be
 manually edited and adjusted to the existing rules in your study area, as
-long as they stick to some basic premises. Please see fare structure
-vignette for more information on how the fare structure works:
-\code{vignette("fare_structure", package = "r5r")}.
+long as they stick to some basic premises. Please see the \link[vignette:fare_structure]{fare structure vignette} for more information.
 }
 \examples{
 \dontshow{if (identical(tolower(Sys.getenv("NOT_CRAN")), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/r-package/vignettes/fare_structure.Rmd
+++ b/r-package/vignettes/fare_structure.Rmd
@@ -202,7 +202,7 @@ Below, we can see that the `fares_per_type` data.frame contains five columns:
 
 -   `mode`: the transport mode to which rules on each row refer to;
 -   `unlimited_transfers`: a logical value `TRUE` or `FALSE` that indicates if that transport mode allows unlimited transfers between trips of the same mode, such as a metro/subway system where the passenger pays a fare to access a station and then can use as many services as she wants as long as she doesn't exit the system;
--   `allow_same_route_transfer`: a logical value indicating if a discounted transfer can be done between vehicles ??? of the same route;
+-   `allow_same_route_transfer`: a logical value indicating if a discounted transfer can be done between vehicles of the same route;
 -   `use_route_fare`: another logical value that indicates if each route will have its own fare, or if all routes in this mode will use the fare indicated in this table;
 -   `fare`: the full fare price of this mode.
 

--- a/r-package/vignettes/pareto_frontier.Rmd
+++ b/r-package/vignettes/pareto_frontier.Rmd
@@ -172,11 +172,12 @@ fare_structure <- r5r::read_fare_structure(file.path(data_path, "fares/fares_poa
 
 In this example, we calculate the Pareto frontier from all origins to all 
 destinations considering multiple cutoffs of monetary costs:
-- $1, which would only allow for walking trips
-- $4.5, which would only allow for rail trips
-- $4.8, which would allow for a single bus trip
-- $7.20, which would allow for bus + bus
-- $8.37, which would allow for walking walking + bus + rail
+
+* $1, which would only allow for walking trips
+* $4.5, which would only allow for rail trips
+* $4.8, which would allow for a single bus trip
+* $7.20, which would allow for bus + bus
+* $8.37, which would allow for walking walking + bus + rail
 
 ```{r}
 departure_datetime <- as.POSIXct("13-05-2019 14:00:00", 
@@ -202,7 +203,7 @@ Moinhos hospital. An optimum route alternative means that one cannot make a fast
 increasing costs, and one cannot make a cheaper trip without increasing travel time.
 
 
-```{r, echo = FALSE, fig.width=7, fig.height=4}
+```{r, echo = FALSE, fig.width=7, fig.height=4, warning=FALSE}
 # select origin and destinations
 pf2 <- dplyr::filter(prtf, to_id == 'farrapos_station'  &
                        from_id %in% c('moinhos_de_vento_hospital', 


### PR DESCRIPTION
While looking at the fare implementation I made some quick style improvements to the documentation.

In addition, if you agree @rafapereirabr I would suggest we rename `first_leg` and `second_leg` in the fare structure object to `alight_leg` and `board_leg` respectively, as I think it is a clearer representation. As far as I understand you can set the transfer limit higher so there can be a 3rd, 4th, etc... number of legs. The fare structure parameter refers to the discount applied during your process of switching modes, which the new variables would better explain.