### PR TITLE
added link to documentation site in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ rJavaEnv::java_quick_install(version = 21)
 
 ## Usage 
 
-<small>[See more details](https://ipeagit.github.io/r5r/reference/index.html)</small>
-
 The package has seven **fundamental functions** :
 
 1. `setup_r5()`
@@ -98,6 +96,8 @@ The package has seven **fundamental functions** :
    
 8. `isochrone()`
    * Returns a `A ⁠POLYGON  "sf" "data.frame"` showing the area that can be reached from an origin point at a given travel time limit.
+
+<small>[See more details about each function here](https://ipeagit.github.io/r5r/reference/index.html)</small>
 
 obs. Most of these functions also allow users to account for monetary travel costs 
 when generating travel time matrices and accessibility estimates. More info on


### PR DESCRIPTION
Added link in usage section to package site with much more detail.

Perhaps the all of the text in the usage section should be scrapped for a link to the package site. Easier to maintain and more info with better formatting.