### PR TITLE
enhancing modify_osm_carspeeds.R

### DIFF
--- a/r-package/R/setup_r5.R
+++ b/r-package/R/setup_r5.R
@@ -16,11 +16,7 @@
 #' stored and where the built `network.dat` will be saved.
 #' @param temp_dir A logical. Whether the `R5` Jar file should be saved to a
 #' temporary directory. Defaults to `FALSE`.
-#' @param elevation A string. The name of the impedance function to be used to
-#' calculate impedance for walking and cycling based on street slopes.
-#' Available options include `TOBLER` (Default) and `MINETTI`, or `NONE` to
-#' ignore elevation. R5 loads elevation data from `.tif` files saved inside the
-#' `data_path` directory. See more info in the Details below.
+#' @param @template elevation For more info see Details below.
 #' @param overwrite A logical. Whether to overwrite an existing `network.dat`
 #' or to use a cached file. Defaults to `FALSE` (i.e. use a cached network).
 #'


### PR DESCRIPTION
- [X] allow choosing elevation method
- [ ] copy supporting data files
- [ ] assert data_path and output_path arent equal
- [ ] overwrite: delete existing pbf in output_path, but only if exactly one 
- [ ] rename build_network and build_modified_network
- [ ] read R df instead of csv file
- [ ]  create r5r_core object wrapper in R