### PR TITLE
Only log accessibility calculations every 1000 origins

### DIFF
--- a/java-r5rcore/src/org/ipea/r5r/Process/R5Process.java
+++ b/java-r5rcore/src/org/ipea/r5r/Process/R5Process.java
@@ -199,8 +199,10 @@ public abstract class R5Process {
                 results.clear();
             }
 
-            LOG.info("{} out of {} origins processed.", totalProcessed.getAndIncrement(), nOrigins);
-
+            int nProcessed = totalProcessed.getAndIncrement();
+            if (nProcessed % 1000 == 0) {
+                LOG.info("{} out of {} origins processed.", nProcessed, nOrigins);
+            }
         } catch (ParseException | FileNotFoundException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Currently if you set `progress=TRUE` in the `accessibility` it logs every origin it processes, which quickly fills up the terminal with large analysis runs (I haven't tested it, but it wouldn't surprise me if the logging is also one of the most computationally intensive parts of the calculation, either). This switches it to log only every 1000th origin. That seemed like a good balance for my use case, but a different interval could be set by just changing the number after the modulo operator.