### PR TITLE
remove fixed java home path

### DIFF
--- a/r-package/.Rbuildignore
+++ b/r-package/.Rbuildignore
@@ -16,4 +16,3 @@
 ^inst/jar/r5-.*\.jar$
 ^man/figures
 ^cran-comments\.md$
-^rjavaenv$

--- a/r-package/.Rprofile
+++ b/r-package/.Rprofile
@@ -1,7 +1,0 @@
-# rJavaEnv begin: Manage JAVA_HOME
-Sys.setenv(JAVA_HOME = 'C:/Users/r1701707/AppData/Local/R/cache/R/rJavaEnv/installed/windows/x64/21') # rJavaEnv
-old_path <- Sys.getenv('PATH') # rJavaEnv
-new_path <- file.path(Sys.getenv('JAVA_HOME'), 'bin') # rJavaEnv
-Sys.setenv(PATH = paste(new_path, old_path, sep = .Platform$path.sep)) # rJavaEnv
-rm(old_path, new_path) # rJavaEnv
-# rJavaEnv end: Manage JAVA_HOME


### PR DESCRIPTION
There is a fixed java-home path committed to the Rprofile. I'm not sure if this is what's making the tests on master fail but nonetheless this should not be committed.

this simply undoes the file commited in #9d71693 https://github.com/ipeaGIT/r5r/commit/9d7169340acd6cce46ba21e81b9c2bbb78fa8373