### PR TITLE
Fail fast on broken feeds, work around conveyal/r5#978

### DIFF
--- a/java-r5rcore/src/org/ipea/r5r/Network/TransitLayerWithShapes.java
+++ b/java-r5rcore/src/org/ipea/r5r/Network/TransitLayerWithShapes.java
@@ -40,7 +40,12 @@ public class TransitLayerWithShapes extends TransitLayer {
         }
 
         if (gtfs.patterns.isEmpty()) {
-            throw new IllegalArgumentException(String.format("Feed %s has no patterns, which means it is either empty or contains errors", gtfs.feedId));
+            throw new IllegalArgumentException(
+                String.format(
+                    "Feed %s has no patterns, which means it is either empty or contains errors. Consider using validate_gtfs from {gtfstools}.",
+                    gtfs.feedId
+                )
+            );
         }
 
         // checksum feed and add to checksum cache


### PR DESCRIPTION
In conveyal/r5#978, we discovered that due to an unfortunate collocation of events if a feed is very broken, all trips will end up in one trip pattern, which makes routing fail. This works around that by failing fast if it detects that patterns have not been properly detected.

Reported by @c-voulgaris