### PR TITLE
crs requirement for elevation in docs

### DIFF
--- a/r-package/man/roxygen/templates/elevation.R
+++ b/r-package/man/roxygen/templates/elevation.R
@@ -2,5 +2,6 @@
 #'        calculate impedance for walking and cycling based on street slopes.
 #'        Available options include `TOBLER` (Default) and `MINETTI`, or `NONE`
 #'        to ignore elevation. R5 loads elevation data from `.tif` files saved
-#'        inside the `data_path` directory. See more info in the Details section
-#'        below.
+#'        inside the `data_path` directory. Elevation raster must be in WGS 84
+#'        (EPSG:4326) coordinate reference system. See more info in the Details
+#'        section below.


### PR DESCRIPTION
Related to #520, adds to docs that elevation raster must be in WGS84.