### PR TITLE
Avoid merge with little jar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 
 # Interpret .rmd as R
 *.Rmd linguist-language=R
+
+# Avoid merge conflicts in little jar
+r-package/inst/jar/r5r.jar merge=ours
+r-package/inst/jar/r5r.jar binary


### PR DESCRIPTION
This pr should in theory tell github to not bother creating merge conflicts for the little jar as mentioned in https://github.com/ipeaGIT/r5r/pull/535#issuecomment-3577408636