### PR TITLE
explicitly convert travel time surface to double on R side, fixes #542

### DIFF
--- a/r-package/R/travel_time_surface.R
+++ b/r-package/R/travel_time_surface.R
@@ -228,7 +228,7 @@ process_surfaces <- function (sfaces) {
 # process a single surface into an R object
 process_surface <- function (sface, zoom, west, north, width, height) {
   methods::new("travel_time_surface",
-    matrix=matrix(sface, height, width, byrow = TRUE),
+    matrix=matrix(as.double(sface), height, width, byrow = TRUE),
     zoom = zoom,
     width = width,
     height = height,


### PR DESCRIPTION
The latest isoband package doesn't support integer input, this explicitly converts to double before isoband generation. This should be included in v2.4.0 to avoid a broken default r5r install #540 @rafapereirabr @alexmgns 