### PR TITLE
Fix r5py docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ and accessibility. A key advantage of `r5r` is that is provides a simple and
 friendly R interface to R<sup>5</sup>, one of the fastest and most robust routing
 engines available.
 
-For ***Python*** users, you might want to check our sister package: [**r5py**](https://r5py.readthedocs.io/en/stable/)!
+For ***Python*** users, you might want to check our sister package: [**r5py**](https://r5py.readthedocs.io/stable/)!
 
 -----
 


### PR DESCRIPTION
Current link is broken. Looks like `/en` is not part of the URL.